### PR TITLE
Remove old maps function call

### DIFF
--- a/inst/shinyApp/output.r
+++ b/inst/shinyApp/output.r
@@ -261,14 +261,7 @@ loadMap <- function()
           ggplot2::scale_x_continuous(limits=c(lon_min, lon_max), expand = c(0, 0), breaks=seq(-180,180,30))
 
         # Separate save plot fixes missing shape layer when saving
-        ggplotSave <<- ggplot2::ggplot() +
-          ggplot2::geom_raster(data = combined_data, ggplot2::aes_string(x="Lon", y = "Lat", fill=mapVar),interpolate = TRUE ) +
-          mapWorld +
-          ggplot2::coord_equal(clip = "off",expand = FALSE) +
-          ggplot2::scale_fill_distiller(palette = mapPalette,type = "div", direction = mapDirection, na.value = "Gray") + #, limits = c(-1,1)*max(abs(combined_data[[mapVar]]))) +
-          ggplot2::labs(x="\u00B0Longitude", y="\u00B0Latitude", title = paste0(input$mapCore, " - ", input$mapYear), fill = mapFill) +
-          ggplot2::scale_y_continuous(limits=c(lat_min, lat_max), expand = c(0, 0), breaks=seq(-90,90,30))+
-          ggplot2::scale_x_continuous(limits=c(lon_min, lon_max), expand = c(0, 0), breaks=seq(-180,180,30))
+        ggplotSave <<- ggplotMap
 
         localPlot <- plotly::ggplotly(p = ggplotMap  )
         plotly::layout(p=localPlot, yaxis = list(tickformat = "\u00B0C", dtick = 10, showgrid=FALSE))


### PR DESCRIPTION
Resolves #57 

### What was done:
- Removed duplicate code 
- In this previous [commit](https://github.com/JGCRI/hectorui/commit/52e250782a72a5440db946fa087ddb9ccd39c64b) we changed the palette for the world maps, but the code was written twice and `ggplotSave` was using the wrong `scale_fill_XXX()` function, resulting in the error detailed in #57
- `ggplotSave` now uses the variable `ggplotMap` instead of calling the same code twice

### Works now :) 
<img width="720" alt="Screen Shot 2022-10-11 at 4 09 42 PM" src="https://user-images.githubusercontent.com/20341158/195189127-b2cbe187-beed-4195-b646-cfa2071c1a05.png">
